### PR TITLE
Update mailing list addresses

### DIFF
--- a/intro.rst
+++ b/intro.rst
@@ -95,7 +95,7 @@ All our members abide to the Carpentry\@UiO code of conduct.
 
 If you wish to teach or help at upcoming workshops,
 please reply to the calls regularly sent to the
-organizers @ swcarpentry dot uio dot no mailing list
-or contact carpadmin @ swcarpentry dot uio dot no.
+organizers @ carpentry dot uio dot no mailing list
+or contact carpadmin @ carpentry dot uio dot no.
 For more information, please refer to
 `the Carpentry@UiO onboarding checklist <https://github.com/uio-carpentry/organisational/blob/master/workshop_operations/onboarding-checklist.md#how-do-i-get-started-with-teaching-a-carpentries-workshop-at-uio>`_


### PR DESCRIPTION
Following the email address updates from swcarpentry.uio.no to carpentry.uio.no.